### PR TITLE
Create chats view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ function App() {
       <Header />
       {id ? null : <RoomPortal onIdSubmit={(id, setId)} />}
       {id ? <ChatPortal id={id} /> : null}
-      {/* <RoomPortal onIdSubmit={(id, setId)} /> */}
       <SmallDotGrid />
       <LargeDotGrid />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import "./stylesheets/Responsive.css";
 // import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Header from "./components/Header";
 import RoomPortal from "./components/RoomPortal";
+import ChatPortal from "./components/ChatPortal";
 import LargeDotGrid from "./components/LargeDotGrid";
 import SmallDotGrid from "./components/SmallDotGrid";
 import useLocalStorage from "./hooks/useLocalStorage";
@@ -12,8 +13,9 @@ function App() {
   return (
     <div className="App">
       <Header />
-      {/* {id ? null : <RoomPortal onIdSubmit={(id, setId)} />} */}
-      <RoomPortal onIdSubmit={(id, setId)} />
+      {id ? null : <RoomPortal onIdSubmit={(id, setId)} />}
+      {id ? <ChatPortal id={id} /> : null}
+      {/* <RoomPortal onIdSubmit={(id, setId)} /> */}
       <SmallDotGrid />
       <LargeDotGrid />
     </div>

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -1,11 +1,30 @@
+import { useState } from "react";
+
 export default function ChatPortal() {
+  const [input, setInput] = useState("");
+
+  const handleOnChange = (e) => {
+    setInput(e.target.value);
+  };
+
   return (
     <div className="chat-portal-wrapper">
-      <div className="box-back-chat">
-        <button className="show-id-btn">Room ID</button>
-      </div>
+      <button className="show-id-btn">Room ID</button>
+      <div className="box-back-chat"></div>
+      <form name="basic" className="message-form">
+        <div className="input-wrapper">
+          <input
+            placeholder="Your message..."
+            className="id-input"
+            value={input}
+            onChange={handleOnChange}
+          />
 
-      <div className="box-front-chat"></div>
+          <button className="send-btn" type="submit">
+            Send
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -10,7 +10,18 @@ export default function ChatPortal() {
   return (
     <div className="chat-portal-wrapper">
       <button className="show-id-btn">Room ID</button>
-      <div className="box-back-chat"></div>
+      <div className="box-back-chat">
+        <p className="receive-bubble">
+          You know I have to tell her! She is going to blame me and I have plans
+          tonight!
+        </p>
+        <p className="send-bubble">
+          I was teaching my friend how to twerk and we accidentally knocked over
+          mom’s favorite lamp 😭😭😭
+        </p>
+
+        <p className="receive-bubble">Hey what happened to the lamp?</p>
+      </div>
       <form name="basic" className="message-form">
         <div className="input-wrapper">
           <input

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -1,0 +1,11 @@
+export default function ChatPortal() {
+  return (
+    <div className="chat-portal-wrapper">
+      <div className="box-back-chat">
+        <button className="show-id-btn">Room ID</button>
+      </div>
+
+      <div className="box-front-chat"></div>
+    </div>
+  );
+}

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -19,8 +19,15 @@ export default function ChatPortal() {
           I was teaching my friend how to twerk and we accidentally knocked over
           mom’s favorite lamp 😭😭😭
         </p>
-
         <p className="receive-bubble">Hey what happened to the lamp?</p>
+        <p className="send-bubble">
+          I was teaching my friend how to twerk and we accidentally knocked over
+          mom’s favorite lamp 😭😭😭
+        </p>
+        <p className="receive-bubble">
+          You know I have to tell her! She is going to blame me and I have plans
+          tonight!
+        </p>
       </div>
       <form name="basic" className="message-form">
         <div className="input-wrapper">

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -11,24 +11,26 @@ export default function ChatPortal() {
     <div className="chat-portal-wrapper">
       <button className="show-id-btn">Room ID</button>
       <div className="box-back-chat">
-        <p className="receive-bubble">
+        <p className="receive-bubble receive-carrot">
           You know I have to tell her! She is going to blame me and I have plans
           tonight!
         </p>
         <p className="receive-name">Stacie</p>
-        <p className="send-bubble">
+        <p className="send-bubble send-carrot">
           I was teaching my friend how to twerk and we accidentally knocked over
           mom’s favorite lamp 😭😭😭
         </p>
         <p className="send-name">You</p>
-        <p className="receive-bubble">What happened to the lamp?</p>
+        <p className="receive-bubble receive-carrot">
+          What happened to the lamp?
+        </p>
         <p className="receive-name">Stacie</p>
-        <p className="send-bubble">
+        <p className="send-bubble send-carrot">
           Ooookay. You can always ask me anything and I promise I won't get mad,
           but now I'm kind of worried.
         </p>
         <p className="send-name">You</p>
-        <p className="receive-bubble">
+        <p className="receive-bubble receive-carrot">
           Before you get mad, I've got to ask you something, but promise you
           won't get mad at me!
         </p>

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -15,19 +15,24 @@ export default function ChatPortal() {
           You know I have to tell her! She is going to blame me and I have plans
           tonight!
         </p>
+        <p className="receive-name">Stacie</p>
         <p className="send-bubble">
           I was teaching my friend how to twerk and we accidentally knocked over
           mom’s favorite lamp 😭😭😭
         </p>
-        <p className="receive-bubble">Hey what happened to the lamp?</p>
+        <p className="send-name">You</p>
+        <p className="receive-bubble">What happened to the lamp?</p>
+        <p className="receive-name">Stacie</p>
         <p className="send-bubble">
-          I was teaching my friend how to twerk and we accidentally knocked over
-          mom’s favorite lamp 😭😭😭
+          Ooookay. You can always ask me anything and I promise I won't get mad,
+          but now I'm kind of worried.
         </p>
+        <p className="send-name">You</p>
         <p className="receive-bubble">
-          You know I have to tell her! She is going to blame me and I have plans
-          tonight!
+          Before you get mad, I've got to ask you something, but promise you
+          won't get mad at me!
         </p>
+        <p className="receive-name">Stacie</p>
       </div>
       <form name="basic" className="message-form">
         <div className="input-wrapper">

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -45,7 +45,7 @@ export default function ChatPortal() {
       </div>
 
       <form name="basic" className="message-form">
-        <div className="input-wrapper">
+        <div className="message-wrapper">
           <textarea
             placeholder="Your message..."
             className="id-input"

--- a/src/components/ChatPortal.js
+++ b/src/components/ChatPortal.js
@@ -1,7 +1,14 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 export default function ChatPortal() {
   const [input, setInput] = useState("");
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    textareaRef.current.style.height = "0px";
+    const scrollHeight = textareaRef.current.scrollHeight;
+    textareaRef.current.style.height = scrollHeight + "px";
+  }, [input]);
 
   const handleOnChange = (e) => {
     setInput(e.target.value);
@@ -36,15 +43,17 @@ export default function ChatPortal() {
         </p>
         <p className="receive-name">Stacie</p>
       </div>
+
       <form name="basic" className="message-form">
         <div className="input-wrapper">
-          <input
+          <textarea
             placeholder="Your message..."
             className="id-input"
             value={input}
             onChange={handleOnChange}
+            ref={textareaRef}
+            // value={currentValue}
           />
-
           <button className="send-btn" type="submit">
             Send
           </button>

--- a/src/components/RoomPortal.js
+++ b/src/components/RoomPortal.js
@@ -21,12 +21,12 @@ export default function RoomPortal({ onIdSubmit }) {
   };
 
   return (
-    <div className="portal-wrapper">
-      <div className="box-back">
+    <div className="room-portal-wrapper">
+      <div className="box-back-room">
         <h3 className="rooms-title">Rooms</h3>
       </div>
 
-      <div className="box-front">
+      <div className="box-front-room">
         <button type="primary" className="create-btn" onClick={createRoomID}>
           Create
         </button>

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -203,6 +203,19 @@ input::placeholder {
 .message-form {
   width: 100%;
   margin-top: 1rem;
+  margin-bottom: 5rem;
+}
+
+textarea {
+  padding: 0.2rem;
+  resize: none;
+  min-height: 2.25rem;
+  max-height: 6rem;
+}
+
+textarea::placeholder {
+  color: #59f8e8;
+  font-size: 1rem;
 }
 
 .send-btn {
@@ -239,12 +252,12 @@ input::placeholder {
   width: 0px;
   height: 0px;
   position: absolute;
-  border-left: 10px solid #f45b69;
-  border-right: 10px solid transparent;
-  border-top: 10px solid #f45b69;
-  border-bottom: 10px solid transparent;
+  border-left: 8px solid #f45b69;
+  border-right: 8px solid transparent;
+  border-top: 8px solid #f45b69;
+  border-bottom: 8px solid transparent;
   left: 19px;
-  bottom: -19px;
+  bottom: -15px;
 }
 
 .send-bubble {
@@ -263,12 +276,12 @@ input::placeholder {
   width: 0px;
   height: 0px;
   position: absolute;
-  border-left: 10px solid transparent;
-  border-right: 10px solid #a682ff;
-  border-top: 10px solid #a682ff;
-  border-bottom: 10px solid transparent;
+  border-left: 8px solid transparent;
+  border-right: 8px solid #a682ff;
+  border-top: 8px solid #a682ff;
+  border-bottom: 8px solid transparent;
   right: 19px;
-  bottom: -19px;
+  bottom: -15px;
 }
 
 .receive-name {

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -230,7 +230,7 @@ input::placeholder {
   font-size: 1.2rem;
   padding: 1rem;
   width: 60%;
-  margin: 1rem;
+  margin-left: 1rem;
 }
 
 .send-bubble {
@@ -239,8 +239,21 @@ input::placeholder {
   font-size: 1.2rem;
   padding: 1rem;
   width: 60%;
-  margin: 1rem;
+  margin-right: 1rem;
   margin-left: auto;
+}
+
+.receive-name {
+  color: #c4c4c4;
+  margin-left: 2rem;
+  margin-bottom: -1rem;
+}
+
+.send-name {
+  color: #c4c4c4;
+  margin-left: auto;
+  margin-right: 2rem;
+  margin-bottom: -1rem;
 }
 
 /* Small dot grid */

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -177,6 +177,9 @@ input::placeholder {
   box-sizing: border-box;
   left: 0;
   top: 0;
+  display: flex;
+  flex-direction: column-reverse;
+  /* align-items: end; */
 }
 
 .show-id-btn {
@@ -217,6 +220,27 @@ input::placeholder {
 
 .send-btn:hover {
   background-color: #f45b69;
+}
+
+/* message bubble styles */
+
+.receive-bubble {
+  border-radius: 1rem;
+  background-color: #f45b69;
+  font-size: 1.2rem;
+  padding: 1rem;
+  width: 60%;
+  margin: 1rem;
+}
+
+.send-bubble {
+  border-radius: 1rem;
+  background-color: #a682ff;
+  font-size: 1.2rem;
+  padding: 1rem;
+  width: 60%;
+  margin: 1rem;
+  margin-left: auto;
 }
 
 /* Small dot grid */

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -208,7 +208,7 @@ input::placeholder {
 
 .message-wrapper {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
 }
 
 textarea {

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -172,6 +172,7 @@ input::placeholder {
 }
 
 .box-back-chat {
+  overflow: auto;
   border: 4px solid #59f8e8;
   height: 60vh;
   box-sizing: border-box;
@@ -179,7 +180,6 @@ input::placeholder {
   top: 0;
   display: flex;
   flex-direction: column-reverse;
-  /* align-items: end; */
 }
 
 .show-id-btn {

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -51,14 +51,13 @@ body {
   color: #c4c4c4;
 }
 
-.portal-wrapper {
-  /* position: absolute; */
+/* room portal box styles */
+.room-portal-wrapper {
   margin-top: 5rem;
   width: 100%;
 }
 
-/* back box styles */
-.box-back {
+.box-back-room {
   height: 15rem;
   border: 4px solid #59f8e8;
   background: #03191e;
@@ -80,8 +79,7 @@ body {
   margin-top: 1rem;
 }
 
-/* back box sty;es */
-.box-front {
+.box-front-room {
   margin-top: -11rem;
   margin-left: 3rem;
   background: #03191e;
@@ -92,7 +90,6 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  place-items: start;
   padding: 2rem;
   position: sticky;
 }
@@ -130,7 +127,7 @@ body {
 
 .input-wrapper {
   display: flex;
-  place-items: center;
+  align-items: center;
 }
 
 .id-input {
@@ -162,6 +159,58 @@ input::placeholder {
 
 .id-btn:hover {
   background-color: #59f8e8;
+}
+
+/* chat portal box styles */
+.chat-portal-wrapper {
+  margin-top: 3rem;
+  width: 100%;
+  height: 60vh;
+}
+
+.box-back-chat {
+  border: 4px solid #59f8e8;
+  height: 100%;
+  background: #03191e;
+  box-sizing: border-box;
+  left: 0;
+  top: 0;
+  width: 95%;
+}
+
+.show-id-btn {
+  margin-top: 1rem;
+  font-family: Roboto;
+  font-size: 1rem;
+  background-color: #59f8e8;
+  color: #03191e;
+  border-radius: 2px;
+  padding: 5px 12px;
+  width: 7rem;
+  border: none;
+  cursor: pointer;
+  margin-left: 0.8rem;
+}
+
+.show-id-btn:hover {
+  background-color: #f45b69;
+}
+
+.box-front-chat {
+  margin-top: -26.5rem;
+  margin-left: 1rem;
+  height: 100%;
+  /* width: 90%; */
+  background: #03191e;
+  z-index: 10;
+  border: 4px solid #59f8e8;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  justify-items: start;
+  padding: 2rem;
+  position: sticky;
 }
 
 /* Small dot grid */

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -231,6 +231,20 @@ input::placeholder {
   padding: 1rem;
   width: 60%;
   margin-left: 1rem;
+  position: relative;
+}
+
+.receive-carrot:before {
+  content: "";
+  width: 0px;
+  height: 0px;
+  position: absolute;
+  border-left: 10px solid #f45b69;
+  border-right: 10px solid transparent;
+  border-top: 10px solid #f45b69;
+  border-bottom: 10px solid transparent;
+  left: 19px;
+  bottom: -19px;
 }
 
 .send-bubble {
@@ -241,6 +255,20 @@ input::placeholder {
   width: 60%;
   margin-right: 1rem;
   margin-left: auto;
+  position: relative;
+}
+
+.send-carrot:before {
+  content: "";
+  width: 0px;
+  height: 0px;
+  position: absolute;
+  border-left: 10px solid transparent;
+  border-right: 10px solid #a682ff;
+  border-top: 10px solid #a682ff;
+  border-bottom: 10px solid transparent;
+  right: 19px;
+  bottom: -19px;
 }
 
 .receive-name {

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -9,7 +9,9 @@ body {
 }
 
 .App {
-  margin: 2rem;
+  margin: 0;
+  margin-left: 2rem;
+  margin-right: 2rem;
 }
 
 .App::-moz-selection {
@@ -163,23 +165,21 @@ input::placeholder {
 
 /* chat portal box styles */
 .chat-portal-wrapper {
-  margin-top: 3rem;
+  margin-top: 2rem;
   width: 100%;
-  height: 60vh;
+  background: #03191ee3;
+  z-index: 10;
 }
 
 .box-back-chat {
   border: 4px solid #59f8e8;
-  height: 100%;
-  background: #03191e;
+  height: 60vh;
   box-sizing: border-box;
   left: 0;
   top: 0;
-  width: 95%;
 }
 
 .show-id-btn {
-  margin-top: 1rem;
   font-family: Roboto;
   font-size: 1rem;
   background-color: #59f8e8;
@@ -189,28 +189,34 @@ input::placeholder {
   width: 7rem;
   border: none;
   cursor: pointer;
-  margin-left: 0.8rem;
+  margin-bottom: 1rem;
 }
 
 .show-id-btn:hover {
   background-color: #f45b69;
 }
 
-.box-front-chat {
-  margin-top: -26.5rem;
+/* message styles */
+.message-form {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.send-btn {
+  font-family: Roboto;
+  font-size: 1.5rem;
+  background-color: #59f8e8;
+  color: #03191e;
+  border-radius: 2px;
+  padding: 5px 12px;
+  width: 7rem;
+  border: none;
+  cursor: pointer;
   margin-left: 1rem;
-  height: 100%;
-  /* width: 90%; */
-  background: #03191e;
-  z-index: 10;
-  border: 4px solid #59f8e8;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  justify-items: start;
-  padding: 2rem;
-  position: sticky;
+}
+
+.send-btn:hover {
+  background-color: #f45b69;
 }
 
 /* Small dot grid */
@@ -219,10 +225,10 @@ input::placeholder {
   position: absolute;
   bottom: 10rem;
   right: 0rem;
+  z-index: -10;
 }
 
 .small-dot-grid {
-  z-index: -10;
   position: relative;
 }
 
@@ -233,9 +239,9 @@ input::placeholder {
   position: absolute;
   bottom: 0rem;
   right: 0rem;
+  z-index: -10;
 }
 
 .large-dot-grid {
-  z-index: -10;
   position: relative;
 }

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -206,10 +206,15 @@ input::placeholder {
   margin-bottom: 5rem;
 }
 
+.message-wrapper {
+  display: flex;
+  align-items: start;
+}
+
 textarea {
   padding: 0.2rem;
   resize: none;
-  min-height: 2.25rem;
+  min-height: 2rem;
   max-height: 6rem;
 }
 
@@ -226,6 +231,7 @@ textarea::placeholder {
   border-radius: 2px;
   padding: 5px 12px;
   width: 7rem;
+  height: 3rem;
   border: none;
   cursor: pointer;
   margin-left: 1rem;
@@ -236,7 +242,6 @@ textarea::placeholder {
 }
 
 /* message bubble styles */
-
 .receive-bubble {
   border-radius: 1rem;
   background-color: #f45b69;

--- a/src/stylesheets/Responsive.css
+++ b/src/stylesheets/Responsive.css
@@ -39,6 +39,16 @@
   .box-front {
     padding: 5rem;
   }
+
+  .receive-bubble {
+    font-size: 1.5rem;
+    width: 50%;
+  }
+
+  .send-bubble {
+    font-size: 1.5rem;
+    width: 50%;
+  }
 }
 
 @media only screen and (min-width: 1280px) {

--- a/src/stylesheets/Responsive.css
+++ b/src/stylesheets/Responsive.css
@@ -31,6 +31,14 @@
   .box-back-chat::-webkit-scrollbar-thumb {
     background-color: #59f8e87a;
   }
+
+  textarea::-webkit-scrollbar {
+    width: 0.75rem;
+  }
+
+  textarea::-webkit-scrollbar-thumb {
+    background-color: #59f8e87a;
+  }
 }
 
 @media only screen and (min-width: 1024px) {

--- a/src/stylesheets/Responsive.css
+++ b/src/stylesheets/Responsive.css
@@ -23,6 +23,14 @@
     bottom: 15rem;
     right: 5rem;
   }
+
+  .box-back-chat::-webkit-scrollbar {
+    width: 0.75rem;
+  }
+
+  .box-back-chat::-webkit-scrollbar-thumb {
+    background-color: #59f8e87a;
+  }
 }
 
 @media only screen and (min-width: 1024px) {

--- a/src/stylesheets/Responsive.css
+++ b/src/stylesheets/Responsive.css
@@ -7,10 +7,16 @@
     font-size: 2rem;
   }
 
-  .portal-wrapper {
+  .room-portal-wrapper {
     margin-left: auto;
     margin-right: auto;
     width: 50%;
+  }
+
+  .chat-portal-wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    width: 75%;
   }
 
   .small-grid-outer {
@@ -43,8 +49,12 @@
 }
 
 @media only screen and (min-width: 1536px) {
-  .portal-wrapper {
+  .room-portal-wrapper {
     width: 33%;
+  }
+
+  .chat-portal-wrapper {
+    width: 50%;
   }
 
   .box-back {


### PR DESCRIPTION
## Description 
Creates the chat/message view after a room has been created. I had to deviate from the Figma design not having two boxes and just the one, for practicality reasons concerning UX. Basically I needed to have more real-estate to work with so that messages don't look to scrunched.

## Related Issues
Closes #9 

## Updates / Features

- Box to hold the messages with `overflow: hidden`
- Custom scroll bar on larger screens to match the look of the app
- Textarea for the input that grows with the text, especially useful on mobile devices
- Textarea has custom scroll bar as well on larger screens
- Separate styled chat bubbles for sender messages and received messages
- Custom carrot on the bubble for both types of messages (sent/received)
- Display name for each message

## UI/UX

| Before  | After |
| ------------- | ------------- |
| Mobile  | Mobile  |
| ![Screenshot (278)](https://user-images.githubusercontent.com/47455758/122963991-6dea9f00-d34c-11eb-9fbf-5c7ee29ee263.png) | ![Screenshot (275)](https://user-images.githubusercontent.com/47455758/122964021-77740700-d34c-11eb-98d6-696e5949ea10.png) |
| Desktop | Desktop |
| ![Screenshot (277)](https://user-images.githubusercontent.com/47455758/122964078-8490f600-d34c-11eb-8854-c7b4e899ffef.png) | ![Screenshot (276)](https://user-images.githubusercontent.com/47455758/122964105-8b1f6d80-d34c-11eb-84ba-efefd5a7351c.png) |

## Q&A

1. On `main` run `git pull`
2. Run `git checkout create-chats-view`
3. Run `yarn install`
4. Run `yarn start`
5. Resize the browser and see how the chats view looks on different screen sizes. Type into the message input and notice how the text area grows with the text for a few lines.